### PR TITLE
Update hex docs main url

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule ExometerZabbix.Mixfile do
 
   defp docs() do
     [
-      main: "Exometer Zabbix Reporter",
+      main: "Exometer.Report.Zabbix",
       source_ref: "v#{@version}",
       source_url: @url
     ]


### PR DESCRIPTION
Fixing the docs url on hex.pm

Currently:
https://hexdocs.pm/exometer_zabbix/Exometer%20Zabbix%20Reporter.html

Fixed: https://hexdocs.pm/exometer_zabbix/Exometer.Report.Zabbix.html